### PR TITLE
Fix capitalization of MindScribe

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -276,7 +276,7 @@ async def send_otp_email(email: str, otp: str):
         msg.attach(MIMEText(body, 'html'))
         
         text_body = f"""
-        Welcome to Mindscribe!
+        Welcome to MindScribe!
         
         Your One-Time Password (OTP) for account verification is: {otp}
         
@@ -1162,7 +1162,7 @@ async def analyze_food(user_email: str = Form(...), file: UploadFile = File(...)
 
 @app.get("/")
 def read_root():
-    return {"message": "Welcome to Mindscribe API!","status": "200"}
+    return {"message": "Welcome to MindScribe API!","status": "200"}
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- fix spelling of MindScribe in OTP email
- update API root welcome message

## Testing
- `python -m py_compile Backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68469c2687388331a89fef23904e1a2d